### PR TITLE
Templates for error pages (404 and default)

### DIFF
--- a/src/DependencyInjection/NumberNineChapterOneExtension.php
+++ b/src/DependencyInjection/NumberNineChapterOneExtension.php
@@ -44,6 +44,19 @@ class NumberNineChapterOneExtension extends ConfigurableExtension implements Pre
 
             $container->prependExtensionConfig($name, $config);
         }
+
+        $paths = [];
+        $appPath = '%kernel.project_dir%/templates/bundles/TwigBundle';
+        $themePath = '%kernel.project_dir%/vendor/numberninecms/chapterone/src/Resources/views/bundles/TwigBundle';
+        /** @var string $projectDir */
+        $projectDir = $container->getParameter('kernel.project_dir');
+
+        if (is_dir(str_replace('%kernel.project_dir%', $projectDir, $appPath))) {
+            $paths[$appPath] = 'Twig';
+        }
+
+        $paths[$themePath] = 'Twig';
+        $container->loadFromExtension('twig', ['paths' => $paths]);
     }
 
     public function loadInternal(array $mergedConfig, ContainerBuilder $container): void

--- a/src/Resources/config/app.yaml
+++ b/src/Resources/config/app.yaml
@@ -1,5 +1,5 @@
 twig:
-    form_themes: ['@ChapterOne/form/tailwind_layout.html.twig']
+    form_themes: ['@NumberNineChapterOne/form/tailwind_layout.html.twig']
 
 framework:
     assets:

--- a/src/Resources/views/bundles/TwigBundle/Exception/error.html.twig
+++ b/src/Resources/views/bundles/TwigBundle/Exception/error.html.twig
@@ -1,0 +1,13 @@
+{% trans_default_domain 'ChapterOne' %}
+{% extends N9_base_template() %}
+
+{% block body %}
+    <div class="container standard-container">
+        <main class="px-3 mb-10">
+            <h1 class="text-header">{{ 'An error occured.'|trans }}</h1>
+            {{ N9_shortcode('[divider]') }}
+            <p class="text-xl mb-5">{{ "Something is broken. Please let us know what you were doing when this error occurred.\nWe will fix it as soon as possible. Sorry for any inconvenience caused."|trans|nl2br }}</p>
+            <p>{{ 'Error code: %1%'|trans({'%1%': status_code}) }}</p>
+        </main>
+    </div>
+{% endblock %}

--- a/src/Resources/views/bundles/TwigBundle/Exception/error404.html.twig
+++ b/src/Resources/views/bundles/TwigBundle/Exception/error404.html.twig
@@ -1,0 +1,12 @@
+{% trans_default_domain 'ChapterOne' %}
+{% extends N9_base_template() %}
+
+{% block body %}
+    <div class="container standard-container">
+        <main class="px-3 mb-10">
+            <h1 class="text-header">{{ 'Page not found.'|trans }}</h1>
+            {{ N9_shortcode('[divider]') }}
+            <p class="text-xl">{{ "We can't seem to find the page you're looking for."|trans }}</p>
+        </main>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Main app can still override them in templates/bundles/TwigBundle